### PR TITLE
Fix: timezone issue in scheduling assistant

### DIFF
--- a/src/components/SchedulingAssistant.tsx
+++ b/src/components/SchedulingAssistant.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { timezones } from "../constants/timezones";
+import { fromZonedTime } from "date-fns-tz";
 
 interface ISchedulingAssistantProps {
   onClose: () => void;
@@ -10,7 +11,7 @@ interface ISchedulingAssistantProps {
 
 const SchedulingAssistant = (props: ISchedulingAssistantProps) => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
-  const [selectedTimezone, setSelectedTimezone] = useState<string>("UTC");
+  const [selectedTimezone, setSelectedTimezone] = useState<string>("America/Los_Angeles"); // Default to Seattle
 
   const handleDateChange = (date: Date | null) => {
     setSelectedDate(date);
@@ -24,7 +25,9 @@ const SchedulingAssistant = (props: ISchedulingAssistantProps) => {
 
   const handleSave = () => {
     if (selectedDate) {
-      const utcDateString = selectedDate.toUTCString();
+      // Convert the selected date/time from the selected timezone to UTC
+      const utcDate = fromZonedTime(selectedDate, selectedTimezone);
+      const utcDateString = utcDate.toUTCString();
       props.setBaseTime(utcDateString);
     }
     props.onClose();
@@ -51,6 +54,7 @@ const SchedulingAssistant = (props: ISchedulingAssistantProps) => {
             onChange={handleTimezoneChange}
             className="timezone-picker"
           >
+            <option value="UTC">UTC</option>
             {timezones.map((tz) => (
               <option key={tz.timezone} value={tz.timezone}>
                 {tz.city} ({tz.timezone})

--- a/src/components/TimezoneCard.tsx
+++ b/src/components/TimezoneCard.tsx
@@ -2,10 +2,7 @@ import { format } from "date-fns";
 import { toZonedTime } from "date-fns-tz";
 import React, { useState, useEffect } from "react";
 
-
-// This component receives UTC time
-// But it is converting the UTC time to local time
-// Need to figure out how to convert the UTC time to specified timezones
+// This component receives UTC time and converts it to the specified timezone
 const TimezoneCard = ({
   time,
   timezone,
@@ -15,11 +12,11 @@ const TimezoneCard = ({
   timezone: string;
   city: string;
 }) => {  
-  const [currentTime, setCurrentTime] = useState(new Date(time)); // this is converting to local time
+  const [currentTime, setCurrentTime] = useState(new Date(time)); // Parse the UTC time
   const [lastUpdate, setLastUpdate] = useState(new Date());
 
   useEffect(() => {
-    setCurrentTime(new Date(time)); // this is converting to local time
+    setCurrentTime(new Date(time)); // Parse the UTC time string
     setLastUpdate(new Date());
   }, [time]);
 
@@ -36,7 +33,8 @@ const TimezoneCard = ({
     return () => clearInterval(timer);
   }, [lastUpdate]);
 
-  const zonedTime = toZonedTime(currentTime, timezone, { timeZone: timezone });
+  // Convert the UTC time to the target timezone
+  const zonedTime = toZonedTime(currentTime, timezone);
 
   return (
     <div className="timezone-card card">


### PR DESCRIPTION
This pull request introduces enhancements to timezone handling in the `SchedulingAssistant` and `TimezoneCard` components. The changes improve the accuracy of timezone conversions, update default timezone settings, and refine the user interface for timezone selection.

### Enhancements to `SchedulingAssistant`:

* Added `fromZonedTime` from `date-fns-tz` to convert selected date/time from the chosen timezone to UTC before saving, ensuring accurate timezone handling. [[1]](diffhunk://#diff-ee4c7c4cc0a936893bbc29d948f553b5dee397ac0a9284c4031a059852ff58c1R5) [[2]](diffhunk://#diff-ee4c7c4cc0a936893bbc29d948f553b5dee397ac0a9284c4031a059852ff58c1L27-R30)
* Changed the default timezone for the scheduling assistant from `UTC` to `America/Los_Angeles` to align with the Seattle default.
* Added "UTC" as an explicit option in the timezone dropdown for better user clarity.

### Improvements to `TimezoneCard`:

* Updated comments and logic to clarify that the component converts UTC time to the specified timezone using `toZonedTime` from `date-fns-tz`. Removed redundant or unclear comments. [[1]](diffhunk://#diff-ad342a3c6a151b2d40ce49413143a0e9e7c17aced49b8c7c3c2a455dbd254f76L5-R5) [[2]](diffhunk://#diff-ad342a3c6a151b2d40ce49413143a0e9e7c17aced49b8c7c3c2a455dbd254f76L39-R37)
* Simplified the `currentTime` state initialization and update logic to focus on parsing UTC time without unnecessary local time references.